### PR TITLE
Fix UMD output name

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,7 +1,6 @@
 import typescript from "@rollup/plugin-typescript";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import commonJs from "@rollup/plugin-commonjs";
-import fs from "fs";
 import pkg from "./package.json" assert { type: 'json' };
 
 export default {
@@ -9,7 +8,7 @@ export default {
   output: [
     {
       file: pkg.browser,
-      name: pkg.browser,
+      name: pkg.name,
       format: "umd",
       sourcemap: "inline",
     },


### PR DESCRIPTION
## Summary
- update rollup configuration to use package name for UMD build
- drop unused `fs` import

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed449ae883279c0ece7b4c61ba86